### PR TITLE
add timeout slider, add expected completion progress ring

### DIFF
--- a/src/operators/generation_operators.py
+++ b/src/operators/generation_operators.py
@@ -174,6 +174,12 @@ class SendRequestOperator(bpy.types.Operator):
         input_inpainting_name = f"{self.uuid}_inpainting.png"
         input_mask_name = f"{self.uuid}_mask.png"
 
+        # Get History Item to save properties
+        history_item = self.get_history_item(context)
+        if history_item is None:
+            self.report({"ERROR"}, "History item not found")
+            return {"CANCELLED"}
+
         # Prepare Request
 
         model_name = diffusion_props.models_available
@@ -199,6 +205,7 @@ class SendRequestOperator(bpy.types.Operator):
         if diffusion_props.random_seed:
             seed = random.randint(1, 1000000)
             diffusion_props.seed = seed
+            history_item.seed = seed
 
         prompt_request["6"]["inputs"]["text"] = diffusion_props.prompt
         prompt_request["3"]["inputs"]["seed"] = seed

--- a/src/panels/backend_panel.py
+++ b/src/panels/backend_panel.py
@@ -16,10 +16,8 @@ class BackendPanel(bpy.types.Panel):
         layout.label(text="Backend Settings")
         layout.prop(backend_properties, "backend_availables")
         layout.prop(backend_properties, "url")
-        layout.prop(backend_properties, "show_token")
 
-        if backend_properties.show_token:
-            layout.prop(backend_properties, "token")
+        layout.prop(backend_properties, "timeout_retry")
 
 
 def register():

--- a/src/panels/history_panel.py
+++ b/src/panels/history_panel.py
@@ -1,4 +1,8 @@
+from typing import Optional
+
 import bpy
+
+# pyright: reportAttributeAccessIssue=false
 
 
 class HistoryPanel(bpy.types.Panel):
@@ -8,10 +12,13 @@ class HistoryPanel(bpy.types.Panel):
     bl_region_type = "UI"
     bl_category = "Diffusion"
 
-    def draw(self, context):
+    def draw(self, context: Optional[bpy.types.Context]):
+        assert context is not None
+
         layout = self.layout
         scene = context.scene
         history_props = scene.history_properties
+        backend_props = scene.backend_properties
 
         layout.label(text="History")
         box = layout.box()
@@ -19,33 +26,53 @@ class HistoryPanel(bpy.types.Panel):
         box.label(text="Generation History", icon="PACKAGE")
         head_row = box.row(align=False)
         split = head_row.split(factor=0.8)
+
         row = split.column().row()
         row.label(text="ID")
         row.label(text="Prompt")
         row.label(text="Seed")
+        row.label(text="Progress")
 
         row = split.column().row()
         row.label(text="Assign")
         row.label(text="Remove")
 
-        for i, mesh_item in enumerate(history_props.history_collection):
-            row = box.row(align=True)
-            split = row.split(factor=0.8)
+        for i, history_item in enumerate(history_props.history_collection):
+            headrow = box.row(align=True)
+            split = headrow.split(factor=0.8)
             row = split.column().row()
-            row.label(text=f"{mesh_item.id}")
-            row.label(text=f"{mesh_item.prompt}")
-            row.label(text=f"{mesh_item.seed}")
+
+            row.label(text=f"{history_item.id}")
+            row.label(text=f"{history_item.prompt}")
+            row.label(text=f"{history_item.seed}")
+
+            if history_item.received:
+                progress_value = 1.0
+            else:
+                timeout_progress_value = (
+                    history_item.fetching_attempts / backend_props.timeout_retry
+                )
+                expected_progress_value = (
+                    history_item.fetching_attempts / backend_props.expected_completion
+                )
+
+                if expected_progress_value >= 1.0:
+                    progress_value = timeout_progress_value
+                else:
+                    progress_value = expected_progress_value
+
+            row.progress(factor=progress_value, type="RING")
 
             row = split.column().row()
             assign_button = row.operator(
                 "diffusion.assign_history", text="", icon="RESTRICT_SELECT_OFF"
             )
-            assign_button.id = mesh_item.id
+            assign_button.id = history_item.id
             remove_button = row.operator(
                 "diffusion.remove_history", text="", icon="REMOVE"
             )
             remove_button.index = i
-            remove_button.id = mesh_item.id
+            remove_button.id = history_item.id
 
 
 def register():

--- a/src/properties/backend_properties.py
+++ b/src/properties/backend_properties.py
@@ -18,15 +18,20 @@ class BackendProperties(bpy.types.PropertyGroup):
         default="http://localhost:8188",
     )
 
-    show_token: bpy.props.BoolProperty(
-        name="Show API Token",
-        description="Toggle to show token",
-        default=False,
+    timeout_retry: bpy.props.IntProperty(
+        name="Timeout Retry",
+        description="Maximum number of retries (1 per second) to fetch the image before a timeout",
+        default=60,
+        min=1,
+        max=1000,
     )
 
-    token: bpy.props.StringProperty(
-        name="Token",
-        description="Token for the backend",
+    expected_completion: bpy.props.IntProperty(
+        name="Expected Completion",
+        description="Expected time in seconds to complete the image generation",
+        default=60,
+        min=1,
+        max=1000,
     )
 
     history_collection_name: bpy.props.StringProperty(

--- a/src/properties/history_properties.py
+++ b/src/properties/history_properties.py
@@ -13,6 +13,7 @@ class HistoryItem(bpy.types.PropertyGroup):
     url: bpy.props.StringProperty(name="Prompt")
     fetching_attempts: bpy.props.IntProperty(name="Seed")
     mesh: bpy.props.StringProperty(name="Mesh")
+    received: bpy.props.BoolProperty(name="Received", default=False)
 
 
 class HistoryProperties(bpy.types.PropertyGroup):


### PR DESCRIPTION

## Description

- add progress ring with expected completion or timeout as fallback
- add timeout configuration using slider for user

### Details

- Progress Ring for each request visible in the History Panel (that actually needs to be reworked a bit)
- In case of request taking longer time than expected (ie, more than last request) the progression ring is set to be render using based on the timeout value as a fallback
- For completions that fail, as the expected value changes, the progress ring render will change every time (small bug that needs to be fixed, just remove the history item otherwise)
- Add a slider for the number of retries (that also acts as timeout)
- Remove backend properties that were not in use (will try to provide a replicate interface in future release)

## Checklist

- [x] Code formatted with Black and isort.
- [ ] Tests updated or added where necessary.
- [ ] Documentation updated where applicable.


